### PR TITLE
Update packages and fix env

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,6 @@
   "dotnet-test-explorer.testArguments": "--environment \"DOTNET_ENVIRONMENT=Development\"",
   "dotnet.unitTests.dotnetTestExtraArgs": {
     "DOTNET_ENVIRONMENT": "Development"
-  }
+  },
+  "snyk.advanced.autoSelectOrganization": true
 }

--- a/ApiTestingDemo.Tests/ApiTestingDemo.Tests.csproj
+++ b/ApiTestingDemo.Tests/ApiTestingDemo.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,18 +10,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Allure.NUnit" Version="2.12.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="NUnit" Version="4.2.2" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.10.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
-    <PackageReference Include="RestAssured.Net" Version="4.7.1" />
-    <PackageReference Include="RestSharp" Version="112.1.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="Allure.NUnit" Version="2.14.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="RestAssured.Net" Version="4.10.0" />
+    <PackageReference Include="RestSharp" Version="113.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ApiTestingDemo.Tests/RestAssured/Tests/ServerApiTests.cs
+++ b/ApiTestingDemo.Tests/RestAssured/Tests/ServerApiTests.cs
@@ -8,7 +8,6 @@ namespace ApiTestingDemo.Tests.RestAssured.Tests;
 
 /// <summary>
 /// API tests for the Server resource focusing on POST /api/Server
-/// Generated from Swagger: https://effizienteauthdemo.azurewebsites.net/swagger/v1/swagger.json
 /// </summary>
 [AllureParentSuite("Server")]
 [Category("Server")]

--- a/ApiTestingDemo.Tests/RestSharp/Tests/LoginTests.cs
+++ b/ApiTestingDemo.Tests/RestSharp/Tests/LoginTests.cs
@@ -57,10 +57,10 @@ public class LoginTests : TestBase
 
         // Step 5: Verify token is present in response
         Assert.That(response.Data, Is.Not.Null, "Response data should not be null");
-        Assert.That(response.Data!.Token, Is.Not.Empty, "Token should not be empty");
+        Assert.That(response.Data!.AccessToken, Is.Not.Empty, "Token should not be empty");
 
         // Step 6: Verify token format (JWT tokens have 3 parts separated by dots)
-        var tokenParts = response.Data.Token.Split('.');
+        var tokenParts = response.Data.AccessToken.Split('.');
         Assert.That(tokenParts.Length, Is.EqualTo(3), "JWT token should have 3 parts");
 
         // Step 7: Verify token expiration is in the future

--- a/ApiTestingDemo.Tests/Shared/Clients/RestSharpClient.cs
+++ b/ApiTestingDemo.Tests/Shared/Clients/RestSharpClient.cs
@@ -193,18 +193,16 @@ public class RestSharpClient : IApiClient
     {
         if ((int)response.StatusCode >= 400)
         {
-            Console.WriteLine("========== HTTP ERROR ==========");
             Console.WriteLine($"Method: {request.Method}");
             Console.WriteLine($"URL: {response.ResponseUri}");
             Console.WriteLine($"Status Code: {(int)response.StatusCode} {response.StatusCode}");
-            
+
             if (body != null)
             {
                 Console.WriteLine($"Request Body: {JsonSerializer.Serialize(body, new JsonSerializerOptions { WriteIndented = true })}");
             }
-            
+
             Console.WriteLine($"Response Body: {response.Content}");
-            Console.WriteLine("================================");
         }
     }
 }

--- a/ApiTestingDemo.Tests/Shared/Models/LoginResponse.cs
+++ b/ApiTestingDemo.Tests/Shared/Models/LoginResponse.cs
@@ -9,38 +9,38 @@ public class LoginResponse
     /// <summary>
     /// JWT authentication token
     /// </summary>
-    public string Token { get; set; } = string.Empty;
-    
+    public string AccessToken { get; set; } = string.Empty;
+
     /// <summary>
     /// Token expiration date and time
     /// </summary>
     public DateTime TokenExpiration { get; set; }
-    
+
     /// <summary>
     /// Unique user identifier
     /// </summary>
     public int UserId { get; set; }
-    
+
     /// <summary>
     /// User's full name
     /// </summary>
     public string Name { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// User's email address
     /// </summary>
     public string Email { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// Refresh token for obtaining new JWT tokens
     /// </summary>
     public string RefreshToken { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// Company associated with the user
     /// </summary>
     public string Company { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// Company key identifier
     /// </summary>

--- a/ApiTestingDemo.Tests/Shared/TestBase.cs
+++ b/ApiTestingDemo.Tests/Shared/TestBase.cs
@@ -71,6 +71,6 @@ public abstract class TestBase
 
         // Step 7: Authenticate and get JWT token
         var response = await authClient.PostAsync<LoginResponse>("/api/users/login", user);
-        AuthToken = response.Data!.Token;
+        AuthToken = response.Data!.AccessToken;
     }
 }

--- a/ApiTestingDemo.Tests/Shared/TestBase.cs
+++ b/ApiTestingDemo.Tests/Shared/TestBase.cs
@@ -70,7 +70,7 @@ public abstract class TestBase
         var authClient = new RestSharpClient(authUrl);
 
         // Step 7: Authenticate and get JWT token
-        var response = await authClient.PostAsync<LoginResponse>("/api/Users/login", user);
+        var response = await authClient.PostAsync<LoginResponse>("/api/users/login", user);
         AuthToken = response.Data!.Token;
     }
 }

--- a/ApiTestingDemo.Tests/appsettings.json
+++ b/ApiTestingDemo.Tests/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "AuthUrl": "https: //abi-testing-dojo-auth-demo.azurewebsites.net",
+  "AuthUrl": "https://abi-testing-dojo-auth-demo.azurewebsites.net",
   "DefaultTimeout": "30000",
   "RetryAttempts": "3",
   "Logging": {

--- a/ApiTestingDemo.Tests/appsettings.json
+++ b/ApiTestingDemo.Tests/appsettings.json
@@ -1,5 +1,5 @@
 {
-  "AuthUrl": "https://effizienteauthdemo.azurewebsites.net",
+  "AuthUrl": "https: //abi-testing-dojo-auth-demo.azurewebsites.net",
   "DefaultTimeout": "30000",
   "RetryAttempts": "3",
   "Logging": {

--- a/ApiTestingDemo.Tests/test.runsettings
+++ b/ApiTestingDemo.Tests/test.runsettings
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
   <TestRunParameters>
-    <Parameter name="AuthUrl" value="https://effizienteauthdemo.azurewebsites.net" />
+    <Parameter name="AuthUrl" value="https://abi-testing-dojo-auth-demo.azurewebsites.net" />
     <Parameter name="DefaultTimeout" value="30000" />
     <Parameter name="RetryAttempts" value="3" />
   </TestRunParameters>


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- Update .NET target framework from net9.0 to net10.0

- Upgrade multiple NuGet packages to latest versions

- Fix API endpoint URL from /api/Server to /api/users/login

- Update authentication URL to new Azure endpoint

- Clean up logging output and remove redundant headers

- Add Snyk organization auto-selection setting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Target Framework<br/>net9.0 → net10.0"] --> B["Updated Dependencies"]
  C["API Endpoint<br/>Case correction"] --> D["Test Configuration"]
  E["Auth URL<br/>New Azure endpoint"] --> D
  F["Logging<br/>Cleanup"] --> G["Code Quality"]
  B --> H["Enhanced Test Suite"]
  D --> H
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ApiTestingDemo.Tests.csproj</strong><dd><code>Upgrade framework and NuGet dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApiTestingDemo.Tests/ApiTestingDemo.Tests.csproj

<ul><li>Upgraded target framework from net9.0 to net10.0<br> <li> Updated Allure.NUnit from 2.12.1 to 2.14.1<br> <li> Upgraded Microsoft.Extensions.Configuration packages from 9.0.9 to <br>10.0.2<br> <li> Updated Microsoft.NET.Test.Sdk from 17.14.1 to 18.0.1<br> <li> Upgraded NUnit from 4.2.2 to 4.4.0 with proper asset configuration<br> <li> Updated NUnit3TestAdapter from 5.1.0 to 6.1.0<br> <li> Upgraded RestAssured.Net from 4.7.1 to 4.10.0<br> <li> Updated RestSharp from 112.1.0 to 113.1.0<br> <li> Removed System.Text.Json package reference</ul>


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-e52845c641beaa7e9943a227d550d6ff17663e70bd569a3cfccef7e3dbf3ceba">+15/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TestBase.cs</strong><dd><code>Fix login endpoint URL case sensitivity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApiTestingDemo.Tests/Shared/TestBase.cs

<ul><li>Fixed API endpoint URL from /api/Users/login to /api/users/login for <br>correct case sensitivity</ul>


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-31d1a7165877b07ab49466ccfa5cc3560a18a85de40bc1b586f4be6a65423e3c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RestSharpClient.cs</strong><dd><code>Clean up HTTP error logging output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApiTestingDemo.Tests/Shared/Clients/RestSharpClient.cs

<ul><li>Removed "========== HTTP ERROR ==========" header from error logging<br> <li> Removed "================================" footer from error logging<br> <li> Fixed whitespace formatting in error response logging</ul>


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-8e3198ab4472e4174716dd597bee3d6d57c3d78ee0c02c42d4b526c032968da2">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>appsettings.json</strong><dd><code>Update authentication URL endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApiTestingDemo.Tests/appsettings.json

<ul><li>Updated AuthUrl from effizienteauthdemo.azurewebsites.net to <br>abi-testing-dojo-auth-demo.azurewebsites.net</ul>


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-39be5dfdd701a7d9eb34a7ced0b8751aa777c7222c01770d37ae3dd55ff7927d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.runsettings</strong><dd><code>Update test run settings authentication URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApiTestingDemo.Tests/test.runsettings

<ul><li>Updated AuthUrl parameter from effizienteauthdemo.azurewebsites.net to <br>abi-testing-dojo-auth-demo.azurewebsites.net</ul>


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-c7eda60972eb1700cfa1ee7d514e872c6a0881fb1f7cb8db5283a9b28f4c3e7f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>settings.json</strong><dd><code>Add Snyk auto-select organization setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.vscode/settings.json

- Added snyk.advanced.autoSelectOrganization setting set to true


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ServerApiTests.cs</strong><dd><code>Remove outdated Swagger URL reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ApiTestingDemo.Tests/RestAssured/Tests/ServerApiTests.cs

<ul><li>Removed outdated Swagger documentation URL reference from class <br>summary</ul>


</details>


  </td>
  <td><a href="https://github.com/effiziente1/API_Testing/pull/3/files#diff-7e59fd8455bc5bb248812f22088c864da87dda393c06c47710d8f83b3d047067">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

